### PR TITLE
Overcoming the following error:

### DIFF
--- a/xhprof/xhprof_lib/display/xhprof.php
+++ b/xhprof/xhprof_lib/display/xhprof.php
@@ -23,7 +23,7 @@ use Sugarcrm\XHProf\Viewer\Templates\Helpers\CurrentPageHelper;
 use Sugarcrm\XHProf\Viewer\Templates\Run\SymbolSearchInputTemplate;
 
 function xhprof_count_format($num) {
-    $num = round($num, 3);
+    $num = round((float)$num, 3);
     if (round($num) == $num) {
         return number_format($num);
     } else {


### PR DESCRIPTION
PHP Fatal error:  Uncaught TypeError: round(): Argument #1 ($num) must be of type int|float, string given in
/var/www/html/performance/xhprof/xhprof_lib/display/xhprof.php:26\nStack trace:\n#0
/var/www/html/performance/xhprof/xhprof_lib/display/xhprof.php(26): round('', 3)\n#1 [internal function]: xhprof_count_format('')\n#2 /var/www/html/performance/xhprof/xhprof_lib/display/xhprof.php(218): call_user_func('xhprof_count_fo...', '')\n#3
/var/www/html/performance/xhprof/xhprof_lib/display/xhprof.php(206): print_column_info(Array, 'bcc', Array)\n#4
/var/www/html/performance/xhprof/xhprof_lib/display/xhprof.php(264): print_function_info(Array)\n#5
/var/www/html/performance/xhprof/xhprof_lib/display/xhprof.php(318): print_flat_data('Top-Level Repor...', Array, 4626, '<a class="btn b...')\n#6
/var/www/html/performance/xhprof/xhprof_lib/display/xhprof.php(194): full_report(Array, Array)\n#7
/var/www/html/performance/templates/RunTemplate.php(63): profiler_report(Array, '', Array, Array)\n#8
/var/www/html/performance/src/php/Controllers/RunController.php(70): Sugarcrm\\XHProf\\Viewer\\Templates\\RunTemplate::render(Array, Array, Array, '')\n#9
/var/www/html/performance/src/php/Controllers/FrontController.php(54): Sugarcrm\\XHProf\\Viewer\\Controllers\\RunController->indexAction()\n#10 /var/www/html/performance/index.php(15):
Sugarcrm\\XHProf\\Viewer\\Controllers\\FrontController->dispatch()\n#11 {main}\n  thrown in
/var/www/html/performance/xhprof/xhprof_lib/display/xhprof.php on line 26